### PR TITLE
All types of landfill get refunded if placed over existing land.

### DIFF
--- a/LandfillPainting/control.lua
+++ b/LandfillPainting/control.lua
@@ -33,7 +33,7 @@ local function tilebuilt(e)
   local placeitem = e.item.name
   local refundcount = 0
   for _,v in pairs(e.tiles) do
-    if tilelookup[v.old_tile.name] == placeitem then
+    if tilelookup[v.old_tile.name] ~= nil then
       refundcount = refundcount + 1
     end
   end


### PR DESCRIPTION
There's also another alternative approach, which would make this unnecessary.
All types of landfill get refunded if placed over existing land.
You get back the type of landfill you placed:
F.e. If you place dirt over a sand island, you get back the same amount of dirt as the size of the sand island