### PR TITLE
Refunds all landfill when placed on sand islands.

### DIFF
--- a/LandfillPainting/control.lua
+++ b/LandfillPainting/control.lua
@@ -13,7 +13,7 @@ local tilelookup =
   ['grass-1'] = 'landfill-grass-1',
   ['grass-2'] = 'landfill-grass-1',
   ['grass-3'] = 'landfill-grass-1',
-  ['grass-4'] = 'landfill-grass-1',
+  ['grass-4'] = 'landfill-grass-1',  
   --['landfill'] = 'landfill',
 
   ['red-desert-0'] = 'landfill-red-desert-1',
@@ -26,6 +26,8 @@ local tilelookup =
   ['sand-3'] = 'landfill-sand-3'
 }
 
+local always_refund_sand_islands = settings.startup['landfillpainting-always-refund-sand-islands'].value
+
 local function tilebuilt(e)
   if not e.item then
     return {count = 0}
@@ -33,7 +35,9 @@ local function tilebuilt(e)
   local placeitem = e.item.name
   local refundcount = 0
   for _,v in pairs(e.tiles) do
-    if tilelookup[v.old_tile.name] == placeitem then
+    local oldname = v.old_tile.name
+    if tilelookup[oldname] == placeitem 
+        or (always_refund_sand_islands and (oldname == 'sand-1' or oldname == 'sand-2')) then
       refundcount = refundcount + 1
     end
   end

--- a/LandfillPainting/settings.lua
+++ b/LandfillPainting/settings.lua
@@ -4,5 +4,13 @@ data:extend({
   name = 'landfillpainting-use-rotation',
   setting_type = 'startup',
   default_value = false
+},
+{
+  type = 'bool-setting',
+  name = 'landfillpainting-always-refund-sand-islands',
+  setting_type = 'startup',
+  default_value = false,
+  hidden = true,
+  --forced_value = true,
 }
 })


### PR DESCRIPTION
controllable via a hidden setting.

requirements: 
if it's possible. It should be free to "paint over" existing islands - regardless of the terrain type. Painting one type of landfill over another will still cost. Painting one variation over another variation will still be free.
Spawned islands will stay as being sand.

I implemented it with one exception:
seablock autoplaced islands are either sand-1 or sand-2
I tried to differentiate autoplaced islands and player placed sand landfill in variations sand-1 and sand-2 (which is only possible if Landfill rotation is enabled), but i didn't found any differences how to detect it.
But I guess, its ok to just refund all tiles of type sand-1 or sand-2 no matter if they are autoplaced or played placed.
